### PR TITLE
Update cached file if the original file changes

### DIFF
--- a/src/Intervention/Image/ImageCache.php
+++ b/src/Intervention/Image/ImageCache.php
@@ -95,6 +95,10 @@ class ImageCache
      */
     public function __call($name, $arguments)
     {
+        if($name == 'make'){
+            $arguments[] = filemtime($arguments[0]);
+        }
+        
         $this->registerCall($name, $arguments);
 
         return $this;


### PR DESCRIPTION
We get both the cached and original file paths and then run filemdate() to compare their modification times. If the cached version is older than the original it'll force an update.
