### PR TITLE
Fixed incorrect use path

### DIFF
--- a/src/Intervention/Image/ImageCache.php
+++ b/src/Intervention/Image/ImageCache.php
@@ -3,7 +3,7 @@
 namespace Intervention\Image;
 
 use Exception;
-use Jeremeamia\SuperClosure\SerializableClosure;
+use SuperClosure\SerializableClosure;
 use Illuminate\Cache\Repository as Cache;
 
 class ImageCache


### PR DESCRIPTION
@olivervogel 
In Laravel5, if I set up config/imagecache.php with the following template:

    'templates' => array(
        'medium' => function($image) {
            return $image->fit(600, 400);
        },
        'large' => function($image) {
            return $image->resize(1024, null, function ($constraint) {
                        $constraint->aspectRatio();
                    });
        }

Then I receive the following error when loading my /{route}/large/filename.jpg

    FatalErrorException in ImageCache.php line 223:
    Class 'Jeremeamia\SuperClosure\SerializableClosure' not found
    in ImageCache.php line 223
at HandleExceptions->fatalExceptionFromError(array('type' => '1', 'message' => 'Class 'Jeremeamia\SuperClosure\SerializableClosure' not found', 'file' => '/home/alex/Work/websites/pixelapes.com/pixelapes-com/vendor/intervention/imagecache/src/Intervention/Image/ImageCache.php', 'line' => '223')) in HandleExceptions.php     line 116
    at HandleExceptions->handleShutdown()

Everything works as expected on the medium size.

Looks like ImageCache.php:6 should be 
    use SuperClosure\SerializableClosure;

Not 
    use Jeremeamia\SuperClosure\SerializableClosure;

If I change it everything works.

I couldn't seem to get tests working on this though. Was getting `PHP Fatal error:  Class 'PHPUnit_Framework_Testcase' not found ` when I tried running vendor/bin/phpunit

Not sure why that was, so please note I haven't been able to run tests on this change :(