### PR TITLE
Usage of  non default laravel cache drivers

### DIFF
--- a/src/Intervention/Image/ImageCache.php
+++ b/src/Intervention/Image/ImageCache.php
@@ -68,8 +68,9 @@ class ImageCache
 
             if (is_a($cache, 'Illuminate\Cache\CacheManager')) {
 
-                // add laravel cache
-                $this->cache = $cache;
+                // add laravel cache and set custom cache_driver if persist
+                $cache_driver = config('imagecache.cache_driver');
+                $this->cache = $cache_driver ? $cache->driver($cache_driver) : $cache;
 
             } else {
                     


### PR DESCRIPTION
- Added imagecache config cache_driver parameter to allow usage of not default laravel cache driver.
  Eg you can use Redis driver as default laravel cache and File driver only for image caching.
