### PR TITLE
Added image config to ImageManager.

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -6,6 +6,7 @@ use Closure;
 use Intervention\Image\ImageManager;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Response as IlluminateResponse;
+use Config;
 
 class ImageCacheController extends BaseController
 {
@@ -41,7 +42,7 @@ class ImageCacheController extends BaseController
         $path = $this->getImagePath($filename);
 
         // image manipulation based on callback
-        $manager = new ImageManager;
+        $manager = new ImageManager(Config::get('image'));
         $content = $manager->cache(function ($image) use ($template, $path) {
 
             if ($template instanceof Closure) {


### PR DESCRIPTION
Current version of library ignores `driver` configure options. This fix adds options to `ImageManager` when it is created in `ImageCacheController`.

`Config::get` is used instead of `configure` function for compatibility with Laravel 4.