### PR TITLE
Added possibility to define Templates with arguments

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -26,7 +26,7 @@ class ImageCacheController extends BaseController
 
             case 'download':
                 return $this->getDownload($filename);
-            
+
             default:
                 return $this->getImage($template, $filename);
         }
@@ -55,7 +55,7 @@ class ImageCacheController extends BaseController
                 // build from filter template
                 $image->make($path)->filter($template);
             }
-            
+
         }, config('imagecache.lifetime'));
 
         return $this->buildResponse($content);
@@ -106,9 +106,14 @@ class ImageCacheController extends BaseController
                 return $template;
 
             // filter template found
-            case class_exists($template):
+            case is_string($template) && class_exists($template):
                 return new $template;
-            
+
+            // filter template is a class with arguments
+            case is_array($template):
+                $rc = new \ReflectionClass(array_shift($template));
+                return $rc->newInstanceArgs($template);
+
             default:
                 // template not found
                 abort(404);
@@ -141,7 +146,7 @@ class ImageCacheController extends BaseController
     /**
      * Builds HTTP response from given image data
      *
-     * @param  string $content 
+     * @param  string $content
      * @return Illuminate\Http\Response
      */
     private function buildResponse($content)

--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -109,7 +109,7 @@ class ImageCacheController extends BaseController
             case is_string($template) && class_exists($template):
                 return new $template;
 
-            // filter template is a class with arguments
+            // filter with arguments template found
             case is_array($template):
                 $rc = new \ReflectionClass(array_shift($template));
                 return $rc->newInstanceArgs($template);


### PR DESCRIPTION
Hi,

I added what I believe is a simple yet very helpful trick. But I obviously may not see the entire picture.

That would fully resolve issues like this one:
https://github.com/Intervention/image/issues/368

And would still hold the security argument:
https://github.com/Intervention/image/issues/241

See basic example:
```php
'templates' => array(
      'small' => 'Intervention\Image\Templates\Small',
      'medium' => 'Intervention\Image\Templates\Medium',
      'large' => 'Intervention\Image\Templates\Large'
  )
```

Would become:
```php
use Intervention\Image\Templates\Fit;

'templates' => array(
      'small' => [Fit::class, 120, 90],
      'medium' => [Fit::class, 240, 180],
      'large' => [Fit::class, 480, 360]
  )
```

And would allow easy customisation.

What are your thoughts?
