### PR TITLE
Added variables to the template classes in the config file

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -3,6 +3,7 @@
 namespace Intervention\Image;
 
 use Closure;
+use Illuminate\Http\Request;
 use Intervention\Image\ImageManager;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Response as IlluminateResponse;
@@ -18,8 +19,10 @@ class ImageCacheController extends BaseController
      * @param  string $filename
      * @return Illuminate\Http\Response
      */
-    public function getResponse($template, $filename)
+    public function getResponse(Request $request, $filename)
     {
+        $template = $request->segment(substr_count(config('imagecache.route'), '/')+2);
+
         switch (strtolower($template)) {
             case 'original':
                 return $this->getOriginal($filename);


### PR DESCRIPTION
Hi,

After a few projects I noticed that I'm actually using one particular (custom) template over and over again, but the only differences are the image sizes.

I made a couple of changes in the packages to add arguments in the template definition.

``` php
'templates' => array(
    'small'     => 'Intervention\Image\Templates\Small',
    'medium'    => ['class'=>'Intervention\Image\Templates\Medium'],
    'large'     => ['class'=>'Intervention\Image\Templates\large', 'args'=>['w'=>200,'h'=>200]],
)
```

As you can see the changes won't break the existing configuration for this package.

I'm about to issue a pull request for the other image package as well because the applyFilter function will get a second parameter, the $args variable.
