### PR TITLE
Priority file source location for configured templates are introduced

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -41,8 +41,8 @@ class ImageCacheController extends BaseController
      */
     public function getImage($template, $filename)
     {
+        $path = $this->getImagePath($filename, $template);
         $template = $this->getTemplate($template);
-        $path = $this->getImagePath($filename);
 
         // image manipulation based on callback
         $manager = new ImageManager(Config::get('image'));
@@ -122,8 +122,20 @@ class ImageCacheController extends BaseController
      * @param  string $filename
      * @return string
      */
-    private function getImagePath($filename)
+    private function getImagePath($filename, $template=null)
     {
+        // find file in priority locations
+        if(!is_null($template) && array_key_exists($template, config('imagecache.priority_paths'))) {
+            foreach(config("imagecache.priority_paths.$template") as $path) {
+                // don't allow '..' in filenames
+                $image_path = $path.'/'.str_replace('..', '', $filename);
+                if (file_exists($image_path) && is_file($image_path)) {
+                    // file found
+                    return $image_path;
+                }
+            }
+        }
+
         // find file
         foreach (config('imagecache.paths') as $path) {
             // don't allow '..' in filenames

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -37,6 +37,30 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Priority Storage Paths
+    |--------------------------------------------------------------------------
+    |
+    | Here you can associte some image source paths
+    | specific to a particular tempalate.
+    |
+    | Example:
+    |
+    | 'blog' => array(
+    |    public_path('images/blog'),
+    |    public_path('upload/blog'),
+    | ),
+    | 'profile' => array(
+    |    public_path('upload/profile'),
+    | ),
+    |
+    */
+
+    'priority_paths' => array(
+
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
     | Manipulation templates
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
In my Laravel 4 project, I have faced the issues that imagecache checks the image name in a number of folders with configured sequence. If same name is found in the first directory so that is served.

I tried to introduce configurable priority directories associated to template to looks for files in those directories first.

As this controller is mainly for Laravel 5. I could not test it in Laravel 5 but config file is common for all, I think.