### PR TITLE
Make ImageCacheController compatible with lumen and laravel

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -4,11 +4,9 @@ namespace Intervention\Image;
 
 use Closure;
 use Intervention\Image\ImageManager;
-use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Response as IlluminateResponse;
-use Config;
 
-class ImageCacheController extends BaseController
+class ImageCacheController
 {
     /**
      * Get HTTP response of either original image file or
@@ -45,7 +43,7 @@ class ImageCacheController extends BaseController
         $path = $this->getImagePath($filename);
 
         // image manipulation based on callback
-        $manager = new ImageManager(Config::get('image'));
+        $manager = new ImageManager(config('image'));
         $content = $manager->cache(function ($image) use ($template, $path) {
 
             if ($template instanceof Closure) {


### PR DESCRIPTION
In the ImageCacheController class, it looks like the BaseController parent class isn't being leveraged and Config::get() can be replaced with the config() helper function. Making those changes the controller becomes compatible with lumen and laravel.   