### PR TITLE
Add missing Content-Length header

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -159,6 +159,7 @@ class ImageCacheController extends BaseController
         return new IlluminateResponse($content, $status_code, array(
             'Content-Type' => $mime,
             'Cache-Control' => 'max-age='.(config('imagecache.lifetime')*60).', public',
+            'Content-Length' => strlen($content),
             'Etag' => $etag
         ));
     }


### PR DESCRIPTION
Currently due to the content-length not being sent to the client, there is no way to get image download progress from a `new XMLHttpRequest()` in javascript, with this PR it will be possible to archive the following:

```ts
const request = new XMLHttpRequest()

request.open('GET', 'path/to/image.png')
request.send()

request.addEventListener('progress', (event: ProgressEvent) => {

    if (event.lengthComputable) {
       console.log(`Current progress: ${ event.loaded / event.total }`)
    } 

})
```