### PR TITLE
Fix 2 failing tests

### DIFF
--- a/tests/ImageCacheTest.php
+++ b/tests/ImageCacheTest.php
@@ -195,7 +195,7 @@ class ImageCacheTest extends PHPUnit_Framework_TestCase
         $manager->shouldReceive('make')->with('foo/bar.jpg')->once()->andReturn($image);
         $cache = Mockery::mock('\Illuminate\Cache\Repository');
         $cache->shouldReceive('get')->with($checksum)->once()->andReturn(false);
-        $cache->shouldReceive('put')->with($checksum, $imagedata, \Mockery::type('Carbon\\Carbon'))->once()->andReturn(false);
+        $cache->shouldReceive('put')->with($checksum, $imagedata, Mockery::type('\Carbon\Carbon'))->once()->andReturn(false);
 
         $img = new ImageCache($manager, $cache);
         $img->make('foo/bar.jpg');
@@ -219,7 +219,7 @@ class ImageCacheTest extends PHPUnit_Framework_TestCase
         $manager->shouldReceive('make')->with('foo/bar.jpg')->once()->andReturn($image);
         $cache = Mockery::mock('\Illuminate\Cache\Repository');
         $cache->shouldReceive('get')->with($checksum)->once()->andReturn(false);
-        $cache->shouldReceive('put')->with($checksum, $imagedata, \Mockery::type('Carbon\\Carbon'))->once()->andReturn(false);
+        $cache->shouldReceive('put')->with($checksum, $imagedata, Mockery::type('\Carbon\Carbon'))->once()->andReturn(false);
 
         $img = new ImageCache($manager, $cache);
         $img->make('foo/bar.jpg');

--- a/tests/ImageCacheTest.php
+++ b/tests/ImageCacheTest.php
@@ -195,7 +195,7 @@ class ImageCacheTest extends PHPUnit_Framework_TestCase
         $manager->shouldReceive('make')->with('foo/bar.jpg')->once()->andReturn($image);
         $cache = Mockery::mock('\Illuminate\Cache\Repository');
         $cache->shouldReceive('get')->with($checksum)->once()->andReturn(false);
-        $cache->shouldReceive('put')->with($checksum, $imagedata, $lifetime)->once()->andReturn(false);
+        $cache->shouldReceive('put')->with($checksum, $imagedata, \Mockery::type('Carbon\\Carbon'))->once()->andReturn(false);
 
         $img = new ImageCache($manager, $cache);
         $img->make('foo/bar.jpg');
@@ -219,7 +219,7 @@ class ImageCacheTest extends PHPUnit_Framework_TestCase
         $manager->shouldReceive('make')->with('foo/bar.jpg')->once()->andReturn($image);
         $cache = Mockery::mock('\Illuminate\Cache\Repository');
         $cache->shouldReceive('get')->with($checksum)->once()->andReturn(false);
-        $cache->shouldReceive('put')->with($checksum, $imagedata, $lifetime)->once()->andReturn(false);
+        $cache->shouldReceive('put')->with($checksum, $imagedata, \Mockery::type('Carbon\\Carbon'))->once()->andReturn(false);
 
         $img = new ImageCache($manager, $cache);
         $img->make('foo/bar.jpg');


### PR DESCRIPTION
Commit d68fda4cdc58b098f28c1a8b88b6a87a80aab7ed changed the cache `put()` method `lifetime` parameter from an int to a `Carbon` instance. This caused the 2 tests to fail with the error:

```
Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_2_Illuminate_Cache_Repository::put("2fff960136929390427f9409eac34c42", "mocked image data", object(Carbon\Carbon)). Either the method was unexpected or its arguments matched no expected argument list for this method
```