### PR TITLE
Output buffering may truncate image output

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -20,6 +20,9 @@ class ImageCacheController extends BaseController
      */
     public function getResponse($template, $filename)
     {
+        // Ensure that output buffering is off:
+        ob_end_clean();
+        
         switch (strtolower($template)) {
             case 'original':
                 return $this->getOriginal($filename);


### PR DESCRIPTION
In some server configurations, output buffering will cause the image content to be truncated by approximately 5 rows of pixels. I confirmed that this happened with both PHP 7.4 and 8.0, using both GD and Imagick drivers.

To verify, I recreated the original issue by using `ob_start()` on the same line in my local MAMP environment. Output was then truncated, and my browser showed an image corrupt message. Swapping it for the correct `ob_end_clean()` resolved the issue on both my development and the production machines.

This just ensures that any automatic output buffering is turned off properly.